### PR TITLE
Fixing license typo by using levenshtein 

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 import parseExpressions from "spdx-expression-parse";
 
 // Import Internal Dependencies
+import { spdxLicenses, closestSpdxLicenses } from "./src/licenses.js";
 import { checkSpdx, checkEveryTruthy, checkSomeTruthy, createSpdxLink } from "./src/utils.js";
 
 export default (licenseID) => {
@@ -9,20 +10,26 @@ export default (licenseID) => {
     throw new TypeError("expecter licenseID to be a strnig");
   }
 
+  const closestLicenseId = handleLicenseId(licenseID);
   try {
-    const data = parseExpressions(licenseID);
+    const data = parseExpressions(closestLicenseId);
 
     return handleLicenseCase(data);
   }
   catch (err) {
     const data = {
       error: true,
-      errorMessage: `Passed license expression was not a valid license expression. Error from spdx-expression-parse: ${err}`
+      // eslint-disable-next-line max-len
+      errorMessage: `Passed license expression '${closestLicenseId}' was not a valid license expression. Error from spdx-expression-parse: ${err}`
     };
 
     return handleLicenseCase(data);
   }
 };
+
+function handleLicenseId(licenseID) {
+  return spdxLicenses.has(licenseID) ? licenseID : closestSpdxLicenses(licenseID);
+}
 
 function handleLicenseCase(data) {
   if (data.error) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 import parseExpressions from "spdx-expression-parse";
 
 // Import Internal Dependencies
-import { spdxLicenses, closestSpdxLicenses } from "./src/licenses.js";
+import { spdxLicenses, closestSpdxLicenseID } from "./src/licenses.js";
 import { checkSpdx, checkEveryTruthy, checkSomeTruthy, createSpdxLink } from "./src/utils.js";
 
 export default (licenseID) => {
@@ -10,9 +10,10 @@ export default (licenseID) => {
     throw new TypeError("expecter licenseID to be a strnig");
   }
 
-  const closestLicenseId = handleLicenseId(licenseID);
+  const closestLicenseID = spdxLicenses.has(licenseID) ?
+    licenseID : closestSpdxLicenseID(licenseID);
   try {
-    const data = parseExpressions(closestLicenseId);
+    const data = parseExpressions(closestLicenseID);
 
     return handleLicenseCase(data);
   }
@@ -20,16 +21,12 @@ export default (licenseID) => {
     const data = {
       error: true,
       // eslint-disable-next-line max-len
-      errorMessage: `Passed license expression '${closestLicenseId}' was not a valid license expression. Error from spdx-expression-parse: ${err}`
+      errorMessage: `Passed license expression '${closestLicenseID}' was not a valid license expression. Error from spdx-expression-parse: ${err}`
     };
 
     return handleLicenseCase(data);
   }
 };
-
-function handleLicenseId(licenseID) {
-  return spdxLicenses.has(licenseID) ? licenseID : closestSpdxLicenses(licenseID);
-}
 
 function handleLicenseCase(data) {
   if (data.error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "spdx-expression-parse": "^3.0.1"
+        "fastest-levenshtein": "^1.0.16",
+        "spdx-expression-parse": "^3.0.1",
+        "spdx-license-ids": "^3.0.12"
       },
       "devDependencies": {
         "@nodesecure/eslint-config": "^1.5.0",
@@ -1860,6 +1862,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -3493,9 +3503,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -5363,6 +5373,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -6517,9 +6532,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA=="
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
     },
     "split": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fastest-levenshtein": "^1.0.16",
-        "spdx-expression-parse": "^3.0.1",
-        "spdx-license-ids": "^3.0.12"
+        "spdx-expression-parse": "^3.0.1"
       },
       "devDependencies": {
         "@nodesecure/eslint-config": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "types": "index.d.ts",
   "homepage": "https://github.com/NodeSecure/licenses-conformance#readme",
   "dependencies": {
-    "spdx-expression-parse": "^3.0.1"
+    "fastest-levenshtein": "^1.0.16",
+    "spdx-expression-parse": "^3.0.1",
+    "spdx-license-ids": "^3.0.12"
   },
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   "homepage": "https://github.com/NodeSecure/licenses-conformance#readme",
   "dependencies": {
     "fastest-levenshtein": "^1.0.16",
-    "spdx-expression-parse": "^3.0.1",
-    "spdx-license-ids": "^3.0.12"
+    "spdx-expression-parse": "^3.0.1"
   },
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.5.0",

--- a/src/licenses.js
+++ b/src/licenses.js
@@ -1,3 +1,12 @@
+// Import Third-party Dependencies
+import * as levenshtein from "fastest-levenshtein";
+
+// CONSTANTS
+const kMaximumLicenseDistance = 1;
+const kFixedLicenseIds = new Map([
+  ["Apache", "Apache-2.0"]
+]);
+
 export const osi = [
   "ZPL-2.0",
   "Zlib",
@@ -249,3 +258,29 @@ export const deprecated = [
   "eCos-2.0",
   "wxWindows"
 ];
+
+export const spdxLicenses = new Set([
+  ...deprecated,
+  ...fsf,
+  ...osi
+]);
+
+/**
+ * @param {!string} licenseID
+ */
+export function closestSpdxLicenses(licenseID) {
+  if (kFixedLicenseIds.has(licenseID)) {
+    return kFixedLicenseIds.get(licenseID);
+  }
+
+  for (const iteratedLicenseId of spdxLicenses) {
+    const distance = levenshtein.distance(licenseID, iteratedLicenseId);
+    if (distance <= kMaximumLicenseDistance) {
+      kFixedLicenseIds.set(licenseID, iteratedLicenseId);
+
+      return iteratedLicenseId;
+    }
+  }
+
+  return licenseID;
+}

--- a/src/licenses.js
+++ b/src/licenses.js
@@ -268,7 +268,7 @@ export const spdxLicenses = new Set([
 /**
  * @param {!string} licenseID
  */
-export function closestSpdxLicenses(licenseID) {
+export function closestSpdxLicenseID(licenseID) {
   if (kFixedLicenseIds.has(licenseID)) {
     return kFixedLicenseIds.get(licenseID);
   }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -21,6 +21,40 @@ test("check the output of MIT license", (tape) => {
   tape.end();
 });
 
+test("check the output of Apache license (it should convert Apache to Apache-2.0)", (tape) => {
+  const mitLicense = licenseConformance("Apache");
+  tape.same(mitLicense,
+    {
+      uniqueLicenseIds: ["Apache-2.0"],
+      spdxLicenseLinks: ["https://spdx.org/licenses/Apache-2.0.html#licenseText"],
+      spdx: {
+        osi: true,
+        fsf: true,
+        fsfAndOsi: true,
+        includesDeprecated: false
+      }
+    }
+  );
+  tape.end();
+});
+
+test("check the output of BSD 3-Clause license (missing hyphen)", (tape) => {
+  const mitLicense = licenseConformance("BSD 3-Clause");
+  tape.same(mitLicense,
+    {
+      uniqueLicenseIds: ["BSD-3-Clause"],
+      spdxLicenseLinks: ["https://spdx.org/licenses/BSD-3-Clause.html#licenseText"],
+      spdx: {
+        osi: true,
+        fsf: true,
+        fsfAndOsi: true,
+        includesDeprecated: false
+      }
+    }
+  );
+  tape.end();
+});
+
 test("check deprecated license cases", (tape) => {
   const deprecatedLicense = licenseConformance("AGPL-1.0");
   tape.same(deprecatedLicense, {
@@ -91,7 +125,7 @@ test("check license that should throw an Error", (tape) => {
   }
   catch (err) {
     // eslint-disable-next-line max-len
-    tape.ok(err, "Passed license expression was not a valid license expression. Error from spdx-expression-parse: Error: `u` at offset 0");
+    tape.ok(err, "Passed license expression 'unreallicense' was not a valid license expression. Error from spdx-expression-parse: Error: `u` at offset 0");
   }
   tape.end();
 });

--- a/tests/licenses.test.js
+++ b/tests/licenses.test.js
@@ -1,0 +1,26 @@
+// Import Third-party Dependencies
+import test from "tape";
+
+// Import Internal Dependencies
+import { closestSpdxLicenseID } from "../src/licenses.js";
+
+// Check everytruthy
+test("it should return the given LicenseID if no record match", (tape) => {
+  tape.same(closestSpdxLicenseID("foooobar"), "foooobar");
+  tape.end();
+});
+
+test("it should fix 'Apache' to 'Apache-2.0'", (tape) => {
+  tape.same(closestSpdxLicenseID("Apache"), "Apache-2.0");
+  tape.end();
+});
+
+test("it should fix 'BSD 3-Clause' to 'BSD-3-Clause'", (tape) => {
+  tape.same(closestSpdxLicenseID("BSD 3-Clause"), "BSD-3-Clause");
+  tape.end();
+});
+
+test("it not should fix 'BSD 3 Clause' because the distance is greater than one", (tape) => {
+  tape.same(closestSpdxLicenseID("BSD 3 Clause"), "BSD 3 Clause");
+  tape.end();
+});

--- a/tests/licenses.test.js
+++ b/tests/licenses.test.js
@@ -20,7 +20,7 @@ test("it should fix 'BSD 3-Clause' to 'BSD-3-Clause'", (tape) => {
   tape.end();
 });
 
-test("it not should fix 'BSD 3 Clause' because the distance is greater than one", (tape) => {
+test("it should not fix 'BSD 3 Clause' because the distance is greater than one", (tape) => {
   tape.same(closestSpdxLicenseID("BSD 3 Clause"), "BSD 3 Clause");
   tape.end();
 });


### PR DESCRIPTION
Note: I'm using a distance of `1` because greater value can cause trouble. For example with a distance of 2:

BSD 3-Clause can became BSD-4-Clause